### PR TITLE
Add check for documenting GraphQL schemas

### DIFF
--- a/lib/document_graphql_schema.ex
+++ b/lib/document_graphql_schema.ex
@@ -1,0 +1,124 @@
+defmodule Nicene.DocumentGraphqlSchema do
+  @moduledoc """
+  This checks that we're documenting our GraphQL schema thoroughly.
+  """
+  @explanation [check: @moduledoc]
+
+  use Credo.Check, base_priority: :high, category: :readability
+
+  @doc false
+  def run(source_file, params \\ []) do
+    issue_meta = IssueMeta.for(source_file, params)
+    Credo.Code.prewalk(source_file, &check_schema_parts(&1, &2, issue_meta))
+  end
+
+  defs =
+    Enum.map(
+      [
+        :field,
+        :scalar,
+        :arg,
+        :object,
+        :input_object,
+        :directive,
+        :interface,
+        :union,
+        :enum,
+        :value
+      ],
+      fn fun ->
+        quote do
+          defp check_schema_parts(
+                 {unquote(fun), meta, [_, [do: {:__block__, _, args}]]} = ast,
+                 issues,
+                 issue_meta
+               ) do
+            if List.keymember?(args, :description, 0) do
+              {ast, issues}
+            else
+              {ast, [issue_for(issue_meta, meta[:line]) | issues]}
+            end
+          end
+
+          defp check_schema_parts({unquote(fun), meta, [_, args]} = ast, issues, issue_meta)
+               when is_list(args) do
+            if Keyword.has_key?(args, :description) do
+              {ast, issues}
+            else
+              {ast, [issue_for(issue_meta, meta[:line]) | issues]}
+            end
+          end
+
+          defp check_schema_parts({unquote(fun), meta, [_, _]} = ast, issues, issue_meta) do
+            {ast, [issue_for(issue_meta, meta[:line]) | issues]}
+          end
+
+          defp check_schema_parts(
+                 {unquote(fun), meta, [_, args, [do: {:__block__, _, body}]]} = ast,
+                 issues,
+                 issue_meta
+               ) do
+            if List.keymember?(body, :description, 0) or Keyword.has_key?(args, :description) do
+              {ast, issues}
+            else
+              {ast, [issue_for(issue_meta, meta[:line]) | issues]}
+            end
+          end
+
+          defp check_schema_parts(
+                 {unquote(fun), meta, [_, _, args, [do: {:__block__, _, body}]]} = ast,
+                 issues,
+                 issue_meta
+               ) do
+            if List.keymember?(body, :description, 0) or Keyword.has_key?(args, :description) do
+              {ast, issues}
+            else
+              {ast, [issue_for(issue_meta, meta[:line]) | issues]}
+            end
+          end
+
+          defp check_schema_parts(
+                 {unquote(fun), meta, [_, args, [do: {:description, _, _}]]} = ast,
+                 issues,
+                 issue_meta
+               ) do
+            {ast, issues}
+          end
+
+          defp check_schema_parts(
+                 {unquote(fun), meta, [_, args, [do: {_, _, body}]]} = ast,
+                 issues,
+                 issue_meta
+               ) do
+            if List.keymember?(body, :description, 0) or Keyword.has_key?(args, :description) do
+              {ast, issues}
+            else
+              {ast, [issue_for(issue_meta, meta[:line]) | issues]}
+            end
+          end
+
+          defp check_schema_parts({unquote(fun), meta, [_, _, args]} = ast, issues, issue_meta) do
+            if Keyword.has_key?(args, :description) do
+              {ast, issues}
+            else
+              {ast, [issue_for(issue_meta, meta[:line]) | issues]}
+            end
+          end
+        end
+      end
+    )
+
+  Module.eval_quoted(__MODULE__, defs)
+
+  defp check_schema_parts(ast, issues, _) do
+    {ast, issues}
+  end
+
+  defp issue_for(issue_meta, line_no) do
+    format_issue(issue_meta,
+      message:
+        "All fields and objects should be documented with the `description` macro or option.",
+      line_no: line_no
+    )
+  end
+end

--- a/mix.exs
+++ b/mix.exs
@@ -6,7 +6,7 @@ defmodule Nicene.MixProject do
   def project do
     [
       app: :nicene,
-      version: "0.1.7",
+      version: "0.2.0",
       elixir: "~> 1.7",
       start_permanent: false,
       description: "A Credo plugin containing additional checks.",

--- a/test/document_graphql_schema_test.exs
+++ b/test/document_graphql_schema_test.exs
@@ -1,0 +1,168 @@
+defmodule Nicene.DocumentGraphqlSchemaTest do
+  use Assertions.Case
+
+  alias Credo.{Issue, SourceFile}
+
+  alias Nicene.DocumentGraphqlSchema
+
+  test "does not warn if everything is documented correctly" do
+    ~S'''
+    defmodule App.Types.User do
+      scalar :time, description: "A time scalar" do
+        parse &Timex.parse(&1.value, "{ISOz}")
+        serialize &Timex.format!(&1, "{ISOz}")
+      end
+
+      directive :mydirective do
+        description "A directive, whatever these things are"
+
+        arg :if, non_null(:boolean), description: "Skipped when true."
+
+        on Language.Field
+
+        instruction fn
+          %{if: true} ->
+            :skip
+          _ ->
+            :include
+        end
+      end
+
+      interface :vehicle do
+        description "An interface for a vehicle"
+        field :wheel_count, :integer, description: "The number of wheels"
+      end
+
+      object :rally_car do
+        description "A type of car for rallying"
+
+        field :wheel_count, :integer, description: "the number of wheels"
+        interface :vehicle
+      end
+
+      union :search_result do
+        description "A search result"
+
+        types [:person, :business]
+        resolve_type fn
+          %Person{}, _ -> :person
+          %Business{}, _ -> :business
+        end
+      end
+
+      enum :share_filter_type, description: "some values in an enum" do
+        value(:all, as: "all", description: "all of the things")
+        value(:own, as: "own") do
+          description "just our own things"
+        end
+      end
+
+      input_object :share_search_input, description: "The input for searching" do
+        field(:args, :arg_type, default_value: "own") do
+          description """
+          A heredoc description to see what's good here.
+          """
+        end
+      end
+
+      object :user do
+        description "A user object"
+
+        field(:identifier, :string, name: "id", description: "An identifier")
+        field :projects, non_null(:projects) do
+          pagination_args()
+          description "Some projects"
+          resolve(&ProjectResolver.list_projects/3)
+        end
+      end
+    end
+    '''
+    |> SourceFile.parse("lib/app/types/user.ex")
+    |> DocumentGraphqlSchema.run([])
+    |> assert_issues([])
+  end
+
+  test "warns if documentation is missing or if documented with `@desc` attribute" do
+    line_numbers = [3, 8, 9, 21, 22, 25, 26, 30, 38, 39, 40, 43, 44, 47, 48, 51]
+
+    expected_issues =
+      Enum.map(line_numbers, fn line_no ->
+        %Issue{
+          category: :readability,
+          check: Nicene.DocumentGraphqlSchema,
+          filename: "lib/app/types/user.ex",
+          line_no: line_no,
+          message:
+            "All fields and objects should be documented with the `description` macro or option."
+        }
+      end)
+
+    ~S'''
+    defmodule App.Types.User do
+      @desc "A scalar time type"
+      scalar :time do
+        parse &Timex.parse(&1.value, "{ISOz}")
+        serialize &Timex.format!(&1, "{ISOz}")
+      end
+
+      directive :mydirective do
+        arg :if, non_null(:boolean)
+
+        on Language.Field
+
+        instruction fn
+          %{if: true} ->
+            :skip
+          _ ->
+            :include
+        end
+      end
+
+      interface :vehicle do
+        field :wheel_count, :integer
+      end
+
+      object :rally_car do
+        field :wheel_count, :integer
+        interface :vehicle
+      end
+
+      union :search_result do
+        types [:person, :business]
+        resolve_type fn
+          %Person{}, _ -> :person
+          %Business{}, _ -> :business
+        end
+      end
+
+      enum :share_filter_type do
+        value(:all, as: "all")
+        value(:own, as: "own")
+      end
+
+      input_object :share_search_input do
+        field(:args, :arg_type, default_value: "own")
+      end
+
+      object :user do
+        field(:identifier, :string, name: "id")
+
+        @desc "A number of wheels on a car"
+        field :projects, non_null(:projects), default: [] do
+          pagination_args()
+          resolve(&ProjectResolver.list_projects/3)
+        end
+      end
+    end
+    '''
+    |> SourceFile.parse("lib/app/types/user.ex")
+    |> DocumentGraphqlSchema.run([])
+    |> assert_issues(expected_issues)
+  end
+
+  defp assert_issues(issues, expected) do
+    assert_lists_equal(issues, expected, fn issue, expected ->
+      assert_structs_equal(issue, expected, [:category, :check, :filename, :line_no, :message])
+    end)
+  end
+end


### PR DESCRIPTION
This is a first take a a check to require documentation for graphql
schemas. Right now it assumes that the following functions are only used
for defining parts of a GraphQL schema:

```elixir
[:field, :scalar, :arg, :object, :input_object, :directive, :interface,
:union, :enum, :value]
```

If we end up with functions that have the same names then we can ingore
just the calls to those specific functions, or we can make this check a
bit more robust, but it would be good to get the context for the
real-world failure before making those changes.

This one is the first that has some abstraction around patterns that we're
matching on in ASTs, which does make things a bit more convoluted, but
also saves us a boatload of repetition, so I decided to go that route at the
expense of making the code a bit harder to comprehend.