### PR TITLE
Warn if Ecto schemas aren't kept with only other schemas

### DIFF
--- a/lib/ecto_schema_directories.ex
+++ b/lib/ecto_schema_directories.ex
@@ -1,0 +1,75 @@
+defmodule Nicene.EctoSchemaDirectories do
+  @moduledoc """
+  Ecto schemas should not be in directories with other types of files.
+  """
+  @explanation [check: @moduledoc]
+
+  use Credo.Check, base_priority: :high, category: :refactoring
+
+  @doc false
+  def run(source_file, params \\ []) do
+    run(source_file, params, [])
+  end
+
+  def run(source_file, params, other_files) do
+    issue_meta = IssueMeta.for(source_file, params)
+
+    funs = Credo.Code.prewalk(source_file, &get_funs/2, %{})
+
+    source_file
+    |> Credo.SourceFile.lines()
+    |> Enum.reduce(%{}, &process_line(&1, &2, funs))
+    |> Enum.map(fn {line_no, definitions} -> {line_no, Enum.reverse(definitions)} end)
+    |> Enum.reduce([], &process_fun(&1, &2, issue_meta))
+  end
+
+  defp get_funs(
+         {op, _, [{:when, _, [{name, [{:line, line_no} | _], _} | _]} | _]} = ast,
+         functions
+       )
+       when op in [:def, :defp] do
+    {ast, Map.put(functions, line_no, name)}
+  end
+
+  defp get_funs({op, _, [{name, [{:line, line_no} | _], _} | _]} = ast, functions)
+       when op in [:def, :defp] do
+    {ast, Map.put(functions, line_no, name)}
+  end
+
+  defp get_funs(ast, functions) do
+    {ast, functions}
+  end
+
+  defp process_line({line_no, line}, acc, funs) when :erlang.is_map_key(line_no, funs) do
+    if Regex.match?(~r/defp? #{funs[line_no]}.*\)$/, line) do
+      acc
+    else
+      def_type =
+        if Regex.match?(~r/defp? #{funs[line_no]}.*\),(\z)|( do: .*)/, line) do
+          :single_line
+        else
+          :multiline
+        end
+
+      Map.update(acc, funs[line_no], [{line_no, def_type}], &[{line_no, def_type} | &1])
+    end
+  end
+
+  defp process_line(_, acc, _) do
+    acc
+  end
+
+  defp process_fun({_, [{_, def_type} | definitions]}, issues, issue_meta) do
+    Enum.reduce(definitions, issues, fn
+      {_, ^def_type}, acc -> acc
+      {line_no, _}, acc -> [issue_for(issue_meta, line_no) | acc]
+    end)
+  end
+
+  defp issue_for(issue_meta, line_no) do
+    format_issue(issue_meta,
+      message: "Inconsistent function definition found",
+      line_no: line_no
+    )
+  end
+end

--- a/lib/ecto_schema_directories.ex
+++ b/lib/ecto_schema_directories.ex
@@ -4,72 +4,67 @@ defmodule Nicene.EctoSchemaDirectories do
   """
   @explanation [check: @moduledoc]
 
+  require Logger
+
   use Credo.Check, base_priority: :high, category: :refactoring
 
   @doc false
   def run(source_file, params \\ []) do
-    run(source_file, params, [])
+    run(source_file, params, other_files(source_file.filename))
   end
 
   def run(source_file, params, other_files) do
     issue_meta = IssueMeta.for(source_file, params)
+    is_schema = Credo.Code.prewalk(source_file, &schema?/2, false)
 
-    funs = Credo.Code.prewalk(source_file, &get_funs/2, %{})
-
-    source_file
-    |> Credo.SourceFile.lines()
-    |> Enum.reduce(%{}, &process_line(&1, &2, funs))
-    |> Enum.map(fn {line_no, definitions} -> {line_no, Enum.reverse(definitions)} end)
-    |> Enum.reduce([], &process_fun(&1, &2, issue_meta))
-  end
-
-  defp get_funs(
-         {op, _, [{:when, _, [{name, [{:line, line_no} | _], _} | _]} | _]} = ast,
-         functions
-       )
-       when op in [:def, :defp] do
-    {ast, Map.put(functions, line_no, name)}
-  end
-
-  defp get_funs({op, _, [{name, [{:line, line_no} | _], _} | _]} = ast, functions)
-       when op in [:def, :defp] do
-    {ast, Map.put(functions, line_no, name)}
-  end
-
-  defp get_funs(ast, functions) do
-    {ast, functions}
-  end
-
-  defp process_line({line_no, line}, acc, funs) when :erlang.is_map_key(line_no, funs) do
-    if Regex.match?(~r/defp? #{funs[line_no]}.*\)$/, line) do
-      acc
+    if is_schema and not Enum.all?(other_files, &schema?/1) do
+      [issue_for(issue_meta, source_file.filename)]
     else
-      def_type =
-        if Regex.match?(~r/defp? #{funs[line_no]}.*\),(\z)|( do: .*)/, line) do
-          :single_line
-        else
-          :multiline
-        end
-
-      Map.update(acc, funs[line_no], [{line_no, def_type}], &[{line_no, def_type} | &1])
+      []
     end
   end
 
-  defp process_line(_, acc, _) do
-    acc
+  defp other_files(filename) do
+    case File.ls("#{Path.dirname(filename)}/*.ex") do
+      {:ok, files} ->
+        read_files(files)
+
+      {:error, error} ->
+        Logger.warn("Unable to get files in same directory - error: #{inspect(error)}")
+        []
+    end
   end
 
-  defp process_fun({_, [{_, def_type} | definitions]}, issues, issue_meta) do
-    Enum.reduce(definitions, issues, fn
-      {_, ^def_type}, acc -> acc
-      {line_no, _}, acc -> [issue_for(issue_meta, line_no) | acc]
+  defp read_files(files) do
+    Enum.reduce(files, [], fn file, acc ->
+      case File.read(file) do
+        {:ok, binary} ->
+          [binary | acc]
+
+        {:error, error} ->
+          Logger.warn("Unable to read file #{file} - #{inspect(error)}")
+          acc
+      end
     end)
   end
 
-  defp issue_for(issue_meta, line_no) do
+  defp schema?(code) do
+    code
+    |> Code.string_to_quoted()
+    |> Credo.Code.prewalk(&schema?/2, false)
+  end
+
+  defp schema?({:schema, _, [schema, _]} = ast, _) when is_binary(schema) do
+    {ast, true}
+  end
+
+  defp schema?(ast, acc) do
+    {ast, acc}
+  end
+
+  defp issue_for(issue_meta, filename) do
     format_issue(issue_meta,
-      message: "Inconsistent function definition found",
-      line_no: line_no
+      message: "#{filename} is in a directory with files that are not Ecto schemas"
     )
   end
 end

--- a/test/ecto_schema_directories_test.exs
+++ b/test/ecto_schema_directories_test.exs
@@ -1,0 +1,94 @@
+defmodule Nicene.EctoSchemaDirectoriesTest do
+  use Assertions.Case
+
+  alias Credo.{Issue, SourceFile}
+
+  alias Nicene.EctoSchemaDirectories
+
+  test "warns if there are non-schemas in the same directory as schemas" do
+    other_files = [
+      """
+      defmodule My.Admin do
+        use Ecto.Schema
+
+        schema "admins" do
+          field(:name, :string)
+        end
+      end
+      """,
+      """
+      defmodule My.Users do
+
+        alias My.{Repo, User}
+
+        def list_all() do
+          Repo.all(User)
+        end
+      end
+      """
+    ]
+
+    """
+    defmodule My.User do
+      use Ecto.Schema
+
+      schema "users" do
+        field(:name, :string)
+      end
+    end
+    """
+    |> SourceFile.parse("lib/my/user.ex")
+    |> EctoSchemaDirectories.run([], other_files)
+    |> assert_issues([
+      %Issue{
+        category: :warning,
+        check: EctoSchemaDirectories,
+        filename: "lib/app/my/file.ex",
+        line_no: 1,
+        message: "My.Schema is in a directory with files that are not Ecto schemas"
+      }
+    ])
+  end
+
+  test "does not warn if there are only Ecto schemas in the directory" do
+    other_files = [
+      """
+      defmodule My.Admin do
+        use Ecto.Schema
+
+        schema "admins" do
+          field(:name, :string)
+        end
+      end
+      """,
+      """
+      defmodule My.Member do
+        use Ecto.Schema
+
+        schema "members" do
+          field(:name, :string)
+        end
+      end
+      """
+    ]
+
+    """
+    defmodule My.User do
+      use Ecto.Schema
+
+      schema "users" do
+        field(:name, :string)
+      end
+    end
+    """
+    |> SourceFile.parse("lib/my/user.ex")
+    |> EctoSchemaDirectories.run([], other_files)
+    |> assert_issues([])
+  end
+
+  defp assert_issues(issues, expected) do
+    assert_lists_equal(issues, expected, fn issue, expected ->
+      assert_structs_equal(issue, expected, [:category, :check, :filename, :line_no, :message])
+    end)
+  end
+end

--- a/test/ecto_schema_directories_test.exs
+++ b/test/ecto_schema_directories_test.exs
@@ -41,11 +41,10 @@ defmodule Nicene.EctoSchemaDirectoriesTest do
     |> EctoSchemaDirectories.run([], other_files)
     |> assert_issues([
       %Issue{
-        category: :warning,
+        category: :refactoring,
         check: EctoSchemaDirectories,
-        filename: "lib/app/my/file.ex",
-        line_no: 1,
-        message: "My.Schema is in a directory with files that are not Ecto schemas"
+        filename: "lib/my/user.ex",
+        message: "lib/my/user.ex is in a directory with files that are not Ecto schemas"
       }
     ])
   end


### PR DESCRIPTION
This is a preliminary implementation of this feature. The determination
of whether a file defines an Ecto schema or not is pretty naive, but it
might be enough. We'll see if we run into edge cases when it's added to
a real application and then we'll update as we get more information.

Resolves #3 