### PR TITLE
Document Ecto schemas

### DIFF
--- a/lib/document_ecto_schema.ex
+++ b/lib/document_ecto_schema.ex
@@ -44,12 +44,27 @@ defmodule Nicene.DocumentEctoSchema do
     end
   end
 
-  defp get_schema_info(
-         {:has_many, meta, [field, _]} = ast,
-         {descriptions, valid_description, fields}
-       ) do
-    {ast, {descriptions, valid_description, [message_for(field, meta[:line]) | fields]}}
-  end
+  defs =
+    Enum.map(
+      [
+        :belongs_to,
+        :has_one,
+        :has_many,
+        :many_to_many
+      ],
+      fn assoc ->
+        quote do
+          defp get_schema_info(
+                 {unquote(assoc), meta, [field | _]} = ast,
+                 {descriptions, valid_description, fields}
+               ) do
+            {ast, {descriptions, valid_description, [message_for(field, meta[:line]) | fields]}}
+          end
+        end
+      end
+    )
+
+  Module.eval_quoted(__MODULE__, defs)
 
   defp get_schema_info(ast, accumulator) do
     {ast, accumulator}

--- a/lib/document_ecto_schema.ex
+++ b/lib/document_ecto_schema.ex
@@ -1,0 +1,69 @@
+defmodule Nicene.DocumentEctoSchema do
+  @moduledoc """
+  Ecto schema associations should be documented
+  """
+  @explanation [check: @moduledoc]
+
+  use Credo.Check, base_priority: :high, category: :readability
+
+  @doc false
+  def run(source_file, params \\ []) do
+    issue_meta = IssueMeta.for(source_file, params)
+
+    Credo.Code.prewalk(source_file, &get_schema_info(&1, &2), {[], nil, []})
+    |> case do
+      {_, _, []} ->
+        []
+
+      {_, description, relationships} ->
+        relationships
+        |> Enum.filter(&not_in_description?(&1, description))
+        |> Enum.map(fn {_, message, line_no} ->
+          format_issue(issue_meta, message: message, line_no: line_no)
+        end)
+    end
+  end
+
+  defp get_schema_info(
+         {:typedoc, _, [description]} = ast,
+         {descriptions, valid_description, fields}
+       ) do
+    {ast, {[description | descriptions], valid_description, fields}}
+  end
+
+  defp get_schema_info(
+         {:type, _, [{:"::", _, [{:t, _, _} | _]}]} = ast,
+         {descriptions, valid_description, fields}
+       ) do
+    case descriptions do
+      [] ->
+        {ast, {[], valid_description, fields}}
+
+      [description | rest] ->
+        {ast, {rest, description, fields}}
+    end
+  end
+
+  defp get_schema_info(
+         {:has_many, meta, [field, _]} = ast,
+         {descriptions, valid_description, fields}
+       ) do
+    {ast, {descriptions, valid_description, [message_for(field, meta[:line]) | fields]}}
+  end
+
+  defp get_schema_info(ast, accumulator) do
+    {ast, accumulator}
+  end
+
+  defp message_for(field_name, line_no) do
+    {
+      Atom.to_string(field_name),
+      "Ecto association #{field_name} should be documented.",
+      line_no
+    }
+  end
+
+  def not_in_description?({field, _, _}, description) do
+    is_nil(description) || not Regex.match?(~r/## Associations.*#{field} -.*/s, description)
+  end
+end

--- a/test/document_ecto_schema_test.exs
+++ b/test/document_ecto_schema_test.exs
@@ -15,15 +15,21 @@ defmodule Nicene.DocumentEctoSchemaTest do
 
       ## Associations
 
+      company - employer of the given user
+      profile - public information from the user
       posts - blog posts written by the given user
       comments - comments on all blog posts written by the user
+      achievements - achievements the user won
       """
       @type t :: %__MODULE__{}
 
       schema("users") do
         field(:name, :string)
+        belongs_to(:company, Company)
+        has_one(:profile, Profile)
         has_many(:posts, Post)
         has_many(:comments, through: [:posts, :comments])
+        many_to_many(:achievements, Achievement, join_through: "user_achievements")
       end
     end
     '''
@@ -33,6 +39,24 @@ defmodule Nicene.DocumentEctoSchemaTest do
   end
 
   test "warns if one field is not documented" do
+    line_numbers = [
+      {"company", 15},
+      {"profile", 16},
+      {"posts", 17},
+      {"achievements", 19}
+    ]
+
+    expected_issues =
+      Enum.map(line_numbers, fn {field, line_no} ->
+        %Issue{
+          category: :readability,
+          check: Nicene.DocumentEctoSchema,
+          filename: "lib/app/user.ex",
+          line_no: line_no,
+          message: "Ecto association #{field} should be documented."
+        }
+      end)
+
     ~S'''
     defmodule App.User do
       use Ecto.Schema
@@ -48,26 +72,27 @@ defmodule Nicene.DocumentEctoSchemaTest do
 
       schema("users") do
         field(:name, :string)
+        belongs_to(:company, Company)
+        has_one(:profile, Profile)
         has_many(:posts, Post)
         has_many(:comments, through: [:posts, :comments])
+        many_to_many(:achievements, Achievement, join_through: "user_achievements")
       end
     end
     '''
     |> SourceFile.parse("lib/app/user.ex")
     |> DocumentEctoSchema.run([])
-    |> assert_issues([
-      %Issue{
-        category: :readability,
-        check: Nicene.DocumentEctoSchema,
-        filename: "lib/app/user.ex",
-        line_no: 15,
-        message: "Ecto association posts should be documented."
-      }
-    ])
+    |> assert_issues(expected_issues)
   end
 
   test "warns if documentation is missing" do
-    line_numbers = [{"posts", 6}, {"comments", 7}]
+    line_numbers = [
+      {"company", 6},
+      {"profile", 7},
+      {"posts", 8},
+      {"comments", 9},
+      {"achievements", 10}
+    ]
 
     expected_issues =
       Enum.map(line_numbers, fn {field, line_no} ->
@@ -86,8 +111,11 @@ defmodule Nicene.DocumentEctoSchemaTest do
 
       schema("users") do
         field(:name, :string)
+        belongs_to(:company, Company)
+        has_one(:profile, Profile)
         has_many(:posts, Post)
         has_many(:comments, through: [:posts, :comments])
+        many_to_many(:achievements, Achievement, join_through: "user_achievements")
       end
     end
     '''

--- a/test/document_ecto_schema_test.exs
+++ b/test/document_ecto_schema_test.exs
@@ -1,0 +1,104 @@
+defmodule Nicene.DocumentEctoSchemaTest do
+  use Assertions.Case
+
+  alias Credo.{Issue, SourceFile}
+
+  alias Nicene.DocumentEctoSchema
+
+  test "does not warn if everything is documented correctly" do
+    ~S'''
+    defmodule App.User do
+      use Ecto.Schema
+
+      @typedoc """
+      A user is a person in our system.
+
+      ## Associations
+
+      posts - blog posts written by the given user
+      comments - comments on all blog posts written by the user
+      """
+      @type t :: %__MODULE__{}
+
+      schema("users") do
+        field(:name, :string)
+        has_many(:posts, Post)
+        has_many(:comments, through: [:posts, :comments])
+      end
+    end
+    '''
+    |> SourceFile.parse("lib/app/user.ex")
+    |> DocumentEctoSchema.run([])
+    |> assert_issues([])
+  end
+
+  test "warns if one field is not documented" do
+    ~S'''
+    defmodule App.User do
+      use Ecto.Schema
+
+      @typedoc """
+      A user is a person in our system.
+
+      ## Associations
+
+      comments - comments on all blog posts written by the user
+      """
+      @type t :: %__MODULE__{}
+
+      schema("users") do
+        field(:name, :string)
+        has_many(:posts, Post)
+        has_many(:comments, through: [:posts, :comments])
+      end
+    end
+    '''
+    |> SourceFile.parse("lib/app/user.ex")
+    |> DocumentEctoSchema.run([])
+    |> assert_issues([
+      %Issue{
+        category: :readability,
+        check: Nicene.DocumentEctoSchema,
+        filename: "lib/app/user.ex",
+        line_no: 15,
+        message: "Ecto association posts should be documented."
+      }
+    ])
+  end
+
+  test "warns if documentation is missing" do
+    line_numbers = [{"posts", 6}, {"comments", 7}]
+
+    expected_issues =
+      Enum.map(line_numbers, fn {field, line_no} ->
+        %Issue{
+          category: :readability,
+          check: Nicene.DocumentEctoSchema,
+          filename: "lib/app/user.ex",
+          line_no: line_no,
+          message: "Ecto association #{field} should be documented."
+        }
+      end)
+
+    ~S'''
+    defmodule App.User do
+      use Ecto.Schema
+
+      schema("users") do
+        field(:name, :string)
+        has_many(:posts, Post)
+        has_many(:comments, through: [:posts, :comments])
+      end
+    end
+    '''
+    |> SourceFile.parse("lib/app/user.ex")
+    |> DocumentEctoSchema.run([])
+    |> assert_issues(expected_issues)
+  end
+
+  defp assert_issues(issues, expected) do
+    assert_lists_equal(issues, expected, fn issue, expected ->
+      assert_structs_equal(issue, expected, [:category, :check, :filename, :line_no, :message])
+    end)
+  end
+end


### PR DESCRIPTION
Hey there :wave:

I saw you have #2 still open, so I tried to implement a solution.
I hope it helps!

### Description

In order to avoid creating a function for each Ecto association, I copy the approach of @devonestes from #5.

I don't know if there is a way to get the `@typedoc` directly from the `@type`, but the idea behind the implementation is the following:
- `@typedoc`s are stacked in a list.
- When the type of the Ecto struct is found (assuming it is declared as `@type t :: ....`), the last `@typedoc` is assumed to be the `typedoc` of this type.

And for detecting the associations without documentation:
- All associations are gathered while traversing the AST, with their possible error message.
- The fields that don't appear in the documentation are mapped as errors.

### Disclaimer

The test `warns if one field is not documented` fails when it isn't the first one to be ran within the test module.
For example, this passes:
```
mix test --seed 829661
```

But this doesn't pass:
```
mix test --seed 125872
```

It throws the following error: 
<details>
<pre>
 1) test warns if one field is not documented (Nicene.DocumentEctoSchemaTest)
     test/document_ecto_schema_test.exs:41
     ** (MatchError) no match of right hand side value: nil
     code: |> DocumentEctoSchema.run([])
     stacktrace:
       (credo) lib/credo/check.ex:222: Credo.Check.add_line_no_options/3
       (credo) lib/credo/check.ex:196: Credo.Check.format_issue/5
       (elixir) lib/enum.ex:1336: Enum."-map/2-lists^map/1-0-"/2
       test/document_ecto_schema_test.exs:84: (test)
</pre>
</details>

I tried taking a look with the debugger, but I couldn't come to a conclusion of what is going wrong with Credo.