### PR TITLE
Add check to configure forbidden namespaces to use from other namespaces

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ erl_crash.dump
 # Ignore package tarball (built via "mix hex.build").
 nicene-*.tar
 
+.elixir_ls

--- a/lib/avoid_forbidden_namespaces.ex
+++ b/lib/avoid_forbidden_namespaces.ex
@@ -36,18 +36,17 @@ defmodule Nicene.AvoidForbiddenNamespaces do
 
   defp check_usage(
          {:__aliases__, meta, [used_namespace | _]} = ast,
-         {issues, current_namespace},
-         from_namespace,
+         {issues, namespace},
+         namespace,
          forbidden_namespaces,
          issue_meta
-       )
-       when current_namespace == from_namespace do
+       ) do
     if used_namespace in forbidden_namespaces do
       {ast,
        {[issue_for(issue_meta, Keyword.get(meta, :line), used_namespace) | issues],
-        current_namespace}}
+        namespace}}
     else
-      {ast, {issues, current_namespace}}
+      {ast, {issues, namespace}}
     end
   end
 

--- a/lib/avoid_forbidden_namespaces.ex
+++ b/lib/avoid_forbidden_namespaces.ex
@@ -1,0 +1,85 @@
+defmodule Nicene.AvoidForbiddenNamespaces do
+  @moduledoc """
+  Avoid calling forbidden namespaces. This is meant to be used for example
+  to avoid calling `AppWeb` from `App` in Phoenix applications.
+  It only works for top level namespaces.
+  """
+
+  @explanation [check: @moduledoc]
+
+  use Credo.Check, base_priority: :high, category: :refactoring
+
+  @doc false
+  def run(source_file, params \\ []) do
+    issue_meta = IssueMeta.for(source_file, params)
+
+    from_namespace = params |> Keyword.get(:from) |> get_namespace()
+
+    forbidden_namespaces =
+      params
+      |> Keyword.get(:forbid)
+      |> Enum.map(fn module ->
+        [_, namespace] = module |> Atom.to_string() |> String.split(".")
+
+        namespace |> String.to_atom()
+      end)
+
+    source_file
+    |> Credo.Code.prewalk(
+      &check_usage(&1, &2, from_namespace, forbidden_namespaces, issue_meta),
+      {[], nil}
+    )
+    |> elem(0)
+  end
+
+  defp check_usage({:defmodule, _, _} = ast, {issues, _current_namespace}, _, _, _) do
+    current_namespace = ast |> Credo.Code.Module.name() |> get_namespace()
+
+    {ast, {issues, current_namespace}}
+  end
+
+  defp check_usage(
+         {:__aliases__, meta, [used_namespace | _]} = ast,
+         {issues, current_namespace},
+         from_namespace,
+         forbidden_namespaces,
+         issue_meta
+       )
+       when current_namespace == from_namespace do
+    if used_namespace in forbidden_namespaces do
+      {ast,
+       {[issue_for(issue_meta, Keyword.get(meta, :line), used_namespace) | issues],
+        current_namespace}}
+    else
+      {ast, {issues, current_namespace}}
+    end
+  end
+
+  defp check_usage(ast, ctx, _, _, _) do
+    {ast, ctx}
+  end
+
+  defp get_namespace(module_name) when is_atom(module_name) do
+    [_ | [namespace | _]] =
+      module_name
+      |> Atom.to_string()
+      |> String.split(".")
+
+    namespace |> String.to_atom()
+  end
+
+  defp get_namespace(module_name) do
+    module_name
+    |> String.split(".")
+    |> hd()
+    |> String.to_atom()
+  end
+
+  defp issue_for(issue_meta, line_no, trigger) do
+    format_issue(issue_meta,
+      message: "Usage of forbidden namespace found",
+      line_no: line_no,
+      trigger: trigger
+    )
+  end
+end

--- a/lib/avoid_forbidden_namespaces.ex
+++ b/lib/avoid_forbidden_namespaces.ex
@@ -18,11 +18,7 @@ defmodule Nicene.AvoidForbiddenNamespaces do
     forbidden_namespaces =
       params
       |> Keyword.get(:forbid)
-      |> Enum.map(fn module ->
-        [_, namespace] = module |> Atom.to_string() |> String.split(".")
-
-        namespace |> String.to_atom()
-      end)
+      |> Enum.map(&get_namespace/1)
 
     source_file
     |> Credo.Code.prewalk(
@@ -60,19 +56,17 @@ defmodule Nicene.AvoidForbiddenNamespaces do
   end
 
   defp get_namespace(module_name) when is_atom(module_name) do
-    [_ | [namespace | _]] =
-      module_name
-      |> Atom.to_string()
-      |> String.split(".")
-
-    namespace |> String.to_atom()
-  end
-
-  defp get_namespace(module_name) do
     module_name
-    |> String.split(".")
+    |> Module.split()
     |> hd()
     |> String.to_atom()
+  end
+
+  defp get_namespace(module_name) when is_binary(module_name) do
+    module_name
+    |> List.wrap()
+    |> Module.concat()
+    |> get_namespace()
   end
 
   defp issue_for(issue_meta, line_no, trigger) do

--- a/lib/avoid_forbidden_namespaces.ex
+++ b/lib/avoid_forbidden_namespaces.ex
@@ -13,11 +13,11 @@ defmodule Nicene.AvoidForbiddenNamespaces do
   def run(source_file, params \\ []) do
     issue_meta = IssueMeta.for(source_file, params)
 
-    from_namespace = params |> Keyword.get(:from) |> get_namespace()
+    from_namespace = params |> Keyword.fetch!(:from) |> get_namespace()
 
     forbidden_namespaces =
       params
-      |> Keyword.get(:forbid)
+      |> Keyword.fetch!(:forbid)
       |> Enum.map(&get_namespace/1)
 
     source_file

--- a/test/avoid_forbidden_namespaces_calls_test.exs
+++ b/test/avoid_forbidden_namespaces_calls_test.exs
@@ -1,0 +1,71 @@
+defmodule Nicene.AvoidForbiddenNamespacesTest do
+  use Assertions.Case
+
+  alias Credo.{Issue, SourceFile}
+
+  alias Nicene.AvoidForbiddenNamespaces
+
+  test "finds issues" do
+    """
+    defmodule App.File do
+      alias AppWeb.Api
+
+      def test() do
+        AppWeb.Endpoint.test()
+        App.Test.test()
+        Other.test()
+        AppMobile.Notification.test()
+      end
+    end
+    """
+    |> SourceFile.parse("lib/app/file.ex")
+    |> AvoidForbiddenNamespaces.run(from: App, forbid: [AppWeb, AppMobile])
+    |> assert_issues([
+      %Issue{
+        category: :refactoring,
+        check: AvoidForbiddenNamespaces,
+        filename: "lib/app/file.ex",
+        line_no: 8,
+        message: "Usage of forbidden namespace found",
+        trigger: AppMobile
+      },
+      %Issue{
+        category: :refactoring,
+        check: AvoidForbiddenNamespaces,
+        filename: "lib/app/file.ex",
+        line_no: 5,
+        message: "Usage of forbidden namespace found",
+        trigger: AppWeb
+      },
+      %Issue{
+        category: :refactoring,
+        check: AvoidForbiddenNamespaces,
+        filename: "lib/app/file.ex",
+        line_no: 2,
+        message: "Usage of forbidden namespace found",
+        trigger: AppWeb
+      }
+    ])
+  end
+
+  test "it doesn't find issues if the module is not restricted" do
+    """
+    defmodule App.File do
+      import AppWeb.Api
+
+      def test() do
+        App.test()
+      end
+    end
+    """
+    |> SourceFile.parse("lib/app/file.ex")
+    |> AvoidForbiddenNamespaces.run(from: AppWeb, forbid: [App])
+    |> assert_issues([])
+  end
+
+  defp assert_issues(issues, expected) do
+    assert_lists_equal(issues, expected, fn issue, expected ->
+      assert_structs_equal(issue, expected, [:category, :check, :filename, :line_no, :message])
+    end)
+  end
+end

--- a/test/avoid_imports_from_current_application_test.exs
+++ b/test/avoid_imports_from_current_application_test.exs
@@ -22,7 +22,7 @@ defmodule Nicene.AvoidImportsFromCurrentApplicationTest do
     end
     """
     |> SourceFile.parse("lib/app/file.ex")
-    |> AvoidImportsFromCurrentApplication.run([namespaces: [App, AppWeb]])
+    |> AvoidImportsFromCurrentApplication.run(namespaces: [App, AppWeb])
     |> assert_issues([
       %Issue{
         category: :refactoring,
@@ -58,7 +58,7 @@ defmodule Nicene.AvoidImportsFromCurrentApplicationTest do
     end
     """
     |> SourceFile.parse("lib/app/file.ex")
-    |> AvoidImportsFromCurrentApplication.run([namespaces: [Apple, AppleWeb]])
+    |> AvoidImportsFromCurrentApplication.run(namespaces: [Apple, AppleWeb])
     |> assert_issues([])
   end
 

--- a/test/unnecessary_pattern_matching_test.exs
+++ b/test/unnecessary_pattern_matching_test.exs
@@ -5,74 +5,74 @@ defmodule Nicene.UnnecessaryPatternMatchingTest do
 
   alias Nicene.UnnecessaryPatternMatching
 
-    test "warns if we're using case statements instead of if statements" do
-      expected_issues = [
-        %Issue{
-          category: :design,
-          check: UnnecessaryPatternMatching,
-          filename: "lib/app/file_test.ex",
-          line_no: 2,
-          message: "Unnecessary pattern matching or guard clause detected"
-        },
-        %Issue{
-          category: :design,
-          check: UnnecessaryPatternMatching,
-          filename: "lib/app/file_test.ex",
-          line_no: 6,
-          message: "Unnecessary pattern matching or guard clause detected"
-        }
-      ]
+  test "warns if we're using case statements instead of if statements" do
+    expected_issues = [
+      %Issue{
+        category: :design,
+        check: UnnecessaryPatternMatching,
+        filename: "lib/app/file_test.ex",
+        line_no: 2,
+        message: "Unnecessary pattern matching or guard clause detected"
+      },
+      %Issue{
+        category: :design,
+        check: UnnecessaryPatternMatching,
+        filename: "lib/app/file_test.ex",
+        line_no: 6,
+        message: "Unnecessary pattern matching or guard clause detected"
+      }
+    ]
 
-      """
-      defmodule App.FileTest do
-        def test(%{} = arg) do
-          Map.keys(arg)
-        end
+    """
+    defmodule App.FileTest do
+      def test(%{} = arg) do
+        Map.keys(arg)
+      end
 
-        def test(%{} = arg, _opts) do
-          Map.keys(arg)
+      def test(%{} = arg, _opts) do
+        Map.keys(arg)
+      end
+    end
+    """
+    |> SourceFile.parse("lib/app/file_test.ex")
+    |> UnnecessaryPatternMatching.run([])
+    |> assert_issues(expected_issues)
+  end
+
+  test "does not warn for correct pattern matching usage" do
+    """
+    defmodule App.FileTest do
+      def test(%{} = arg) do
+        Map.keys(arg)
+      end
+
+      def test(arg) do
+        {:error, :should_be_a_map}
+      end
+    end
+    """
+    |> SourceFile.parse("test/app/file_test.ex")
+    |> UnnecessaryPatternMatching.run([])
+    |> assert_issues([])
+  end
+
+  test "does not error" do
+    """
+      defmodule Sketchql.CreditUtils do
+        alias Sketchql.Credits.Credit
+
+        def gen_credit_amount do
+          min = Credit.const_min_amount() - 1
+          max = Credit.const_max_amount() - 1
+
+          Faker.random_between(min, max)
         end
       end
-      """
-      |> SourceFile.parse("lib/app/file_test.ex")
-      |> UnnecessaryPatternMatching.run([])
-      |> assert_issues(expected_issues)
-    end
-
-    test "does not warn for correct pattern matching usage" do
-      """
-      defmodule App.FileTest do
-        def test(%{} = arg) do
-          Map.keys(arg)
-        end
-
-        def test(arg) do
-          {:error, :should_be_a_map}
-        end
-      end
-      """
-      |> SourceFile.parse("test/app/file_test.ex")
-      |> UnnecessaryPatternMatching.run([])
-      |> assert_issues([])
-    end
-
-    test "does not error" do
-      """
-        defmodule Sketchql.CreditUtils do
-          alias Sketchql.Credits.Credit
-
-          def gen_credit_amount do
-            min = Credit.const_min_amount() - 1
-            max = Credit.const_max_amount() - 1
-
-            Faker.random_between(min, max)
-          end
-        end
-      """
-      |> SourceFile.parse("test/app/file_test.ex")
-      |> UnnecessaryPatternMatching.run([])
-      |> assert_issues([])
-    end
+    """
+    |> SourceFile.parse("test/app/file_test.ex")
+    |> UnnecessaryPatternMatching.run([])
+    |> assert_issues([])
+  end
 
   defp assert_issues(issues, expected) do
     assert_lists_equal(issues, expected, fn issue, expected ->


### PR DESCRIPTION
This is meant to be used for example to avoid calling `AppWeb` from `App` in Phoenix applications.

For now I built a simple version where only top level namespaces are supported and it only allows configuring one `module -> restrictions` set per check.