### PR TITLE
Add a helper which allows check tests to mark up expected failures

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -9,6 +9,7 @@ defmodule Nicene.MixProject do
       version: "0.5.0",
       elixir: "~> 1.7",
       start_permanent: false,
+      elixirc_paths: elixirc_paths(Mix.env()),
       description: "A Credo plugin containing additional checks.",
       deps: deps(),
       package: package(),
@@ -41,6 +42,9 @@ defmodule Nicene.MixProject do
       }
     ]
   end
+
+  defp elixirc_paths(:test), do: ["lib", "test/support"]
+  defp elixirc_paths(_), do: ["lib"]
 
   defp deps() do
     [

--- a/mix.exs
+++ b/mix.exs
@@ -48,7 +48,7 @@ defmodule Nicene.MixProject do
 
   defp deps() do
     [
-      {:assertions, "~> 0.15.0", only: [:test]},
+      {:assertions, "~> 0.17.0", only: [:test]},
       {:ex_doc, ">= 0.0.0", only: :dev, runtime: false},
       {:credo, "~> 1.2.0"}
     ]

--- a/mix.lock
+++ b/mix.lock
@@ -1,6 +1,6 @@
 %{
   "absinthe": {:hex, :absinthe, "1.5.0-rc.2", "132ceb90783a39454cba1a043e833add5385036ed1e6fe8e889b85fc2b7cd89f", [:mix], [{:dataloader, "~> 1.0.0", [hex: :dataloader, repo: "hexpm", optional: true]}, {:decimal, "~> 1.0", [hex: :decimal, repo: "hexpm", optional: true]}, {:nimble_parsec, "~> 0.5", [hex: :nimble_parsec, repo: "hexpm", optional: false]}, {:telemetry, "~> 0.4.0", [hex: :telemetry, repo: "hexpm", optional: false]}], "hexpm"},
-  "assertions": {:hex, :assertions, "0.15.0", "de3af84b0639dd7bb6fd7c9aa239e705b4f00e1117ff45ad20e4061a5242318e", [:mix], [], "hexpm", "caf34fe03f4a30edc0bac5452181f89bf0f41314f178f31f9bc014b3cea9dff0"},
+  "assertions": {:hex, :assertions, "0.17.0", "97a85414019b3270315f9fee15d4f12b6b5700b4593cf1eb646081a72617e7c9", [:mix], [], "hexpm", "231aa054a6c43818dddf8f4b437f1fca5f84c6e946ae3e52ce0428fca8b25a95"},
   "bunt": {:hex, :bunt, "0.2.0", "951c6e801e8b1d2cbe58ebbd3e616a869061ddadcc4863d0a2182541acae9a38", [:mix], [], "hexpm", "7af5c7e09fe1d40f76c8e4f9dd2be7cebd83909f31fee7cd0e9eadc567da8353"},
   "credo": {:hex, :credo, "1.2.0", "a6a0020ea014ec0eb295c24e43ea24e2cf50b9f987a9ba86bb1f40816662e830", [:mix], [{:bunt, "~> 0.2.0", [hex: :bunt, repo: "hexpm", optional: false]}, {:jason, "~> 1.0", [hex: :jason, repo: "hexpm", optional: false]}], "hexpm", "8aafa008f8d5d059f4c0dfa7d200dd3ae27ebc8d7d2c2571ef819d55bf371434"},
   "earmark": {:hex, :earmark, "1.4.3", "364ca2e9710f6bff494117dbbd53880d84bebb692dafc3a78eb50aa3183f2bfd", [:mix], [], "hexpm", "8cf8a291ebf1c7b9539e3cddb19e9cef066c2441b1640f13c34c1d3cfc825fec"},

--- a/test/support/expect_issues.ex
+++ b/test/support/expect_issues.ex
@@ -50,12 +50,10 @@ defmodule Nicene.ExpectIssues do
 
   def assert_issues(issues, expected) do
     assert_lists_equal(issues, expected, fn issue, expected ->
-      assert_structs_equal(issue, expected, [:category, :check, :filename, :line_no])
-      if match?(%Regex{}, expected.message) do
+      if expected.message do
         assert Regex.match?(expected.message, issue.message)
-      else
-        true
       end
+      assert_structs_equal(issue, expected, [:category, :check, :filename, :line_no])
     end)
   end
 end

--- a/test/support/expect_issues.ex
+++ b/test/support/expect_issues.ex
@@ -1,0 +1,61 @@
+defmodule Nicene.ExpectIssues do
+  require Assertions
+
+  import ExUnit.Assertions, only: [assert: 1]
+  import Assertions, only: [assert_lists_equal: 3, assert_structs_equal: 3]
+
+  def assert_expected_issues(source_file, checker, expected_count) do
+    expected_issues =
+      [source_file]
+      |> Credo.Check.ConfigCommentFinder.run(nil, [])
+      |> Enum.flat_map(fn {filename, comments} ->
+        comments
+        |> Enum.map(fn comment ->
+          make_expected_issue_list(comment.instruction, filename, checker, comment)
+        end)
+        |> List.flatten()
+      end)
+
+    assert Enum.count(expected_issues) == expected_count
+
+    source_file
+    |> checker.run([])
+    |> assert_issues(expected_issues)
+  end
+
+  defp make_expected_issue_list("expect-next-line", filename, checker, comment) do
+    make_expected_issue_list("expect-next-lines:1", filename, checker, comment)
+  end
+
+  defp make_expected_issue_list("expect-next-lines:" <> line_count, filename, checker, comment) do
+    1..String.to_integer(line_count)
+    |> Enum.map(fn offset ->
+      %Credo.Issue{
+        filename: filename,
+        category: checker.category,
+        check: checker,
+        line_no: comment.line_no + offset
+      }
+      |> add_params(comment.params)
+    end)
+  end
+
+  defp add_params(issue, []) do
+    issue
+  end
+
+  defp add_params(issue, [%Regex{} = pattern]) do
+    %{issue | message: pattern}
+  end
+
+  def assert_issues(issues, expected) do
+    assert_lists_equal(issues, expected, fn issue, expected ->
+      assert_structs_equal(issue, expected, [:category, :check, :filename, :line_no])
+      if match?(%Regex{}, expected.message) do
+        assert Regex.match?(expected.message, issue.message)
+      else
+        true
+      end
+    end)
+  end
+end


### PR DESCRIPTION
This makes test source files easier to read and edit, as we don’t need to manually update a list of line numbers after changes.

Currently supported are `# credo:expect-next-line` and `# credo:expect-next-lines:«n»`
A `/pattern/` can optionally be included if the message needs to be tested as well.