### PR TITLE
Allow nested modules to not trigger public functions first warning.

### DIFF
--- a/lib/unnecessary_pattern_matching.ex
+++ b/lib/unnecessary_pattern_matching.ex
@@ -16,8 +16,8 @@ defmodule Nicene.UnnecessaryPatternMatching do
 
     single_definitions =
       source_file
-      |> Credo.Code.prewalk(&Traverse.get_funs/2)
-      |> Enum.map(fn {_, name, arity, _} -> {name, arity} end)
+      |> Traverse.get_funs()
+      |> Enum.map(fn {_, _, name, arity, _} -> {name, arity} end)
       |> Enum.reduce(%{}, fn fun, acc -> Map.update(acc, fun, 1, &(&1 + 1)) end)
       |> Enum.filter(fn {{_, arity}, count} -> count == 1 and arity != 0 end)
       |> Enum.map(&elem(&1, 0))

--- a/test/public_functions_first_test.exs
+++ b/test/public_functions_first_test.exs
@@ -94,6 +94,39 @@ defmodule Nicene.PublicFunctionsFirstTest do
     |> assert_issues([])
   end
 
+  test "multiple modules have functions considered inedpendently" do
+    """
+    defmodule NiceneReport do
+      @moduledoc false
+
+      alias NiceneReport.Result
+
+      def hello do
+        result()
+      end
+
+      defp result do
+        Result.world()
+      end
+
+      defmodule Result do
+        @moduledoc false
+
+        def world do
+          world_atom()
+        end
+
+        defp world_atom do
+          :world
+        end
+      end
+    end
+    """
+    |> SourceFile.parse("lib/app/file.ex")
+    |> PublicFunctionsFirst.run([])
+    |> assert_issues([])
+  end
+
   defp assert_issues(issues, expected) do
     assert_lists_equal(issues, expected, fn issue, expected ->
       assert_structs_equal(issue, expected, [:category, :check, :filename, :line_no, :message])


### PR DESCRIPTION
This allows modules to include nested modules whose private functions
do not "count" towards the enclosing functions public functions first
check.

https://github.com/sketch-hq/nicene/issues/23