### PR TITLE
Adjust credo dep to allow non-breaking versions

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -46,7 +46,7 @@ defmodule Nicene.MixProject do
     [
       {:assertions, "~> 0.15.0", only: [:test]},
       {:ex_doc, ">= 0.0.0", only: :dev, runtime: false},
-      {:credo, "~> 1.2.0"}
+      {:credo, "~> 1.2"}
     ]
   end
 end


### PR DESCRIPTION
current dependency resolution throws an error/warning if your project is using the latest credo version.