### PR TITLE
Remove `priv/` from package

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -29,7 +29,6 @@ defmodule Nicene.MixProject do
   defp package() do
     [
       files: [
-        "priv",
         "lib",
         "mix.exs",
         "README.md",


### PR DESCRIPTION
This directory was removed in https://github.com/sketch-hq/nicene/pull/31
