### PR TITLE
Make sure ecto schema and embedded schemas can co-exist 

### DIFF
--- a/lib/ecto_schema_directories.ex
+++ b/lib/ecto_schema_directories.ex
@@ -56,6 +56,10 @@ defmodule Nicene.EctoSchemaDirectories do
     {ast, true}
   end
 
+  defp schema?({:embedded_schema, _, _} = ast, _) do
+    {ast, true}
+  end
+
   defp schema?(ast, acc) do
     {ast, acc}
   end

--- a/test/ecto_schema_directories_test.exs
+++ b/test/ecto_schema_directories_test.exs
@@ -85,6 +85,42 @@ defmodule Nicene.EctoSchemaDirectoriesTest do
     |> assert_issues([])
   end
 
+  test "does not warn if there are embed Ecto schemas in the directory" do
+    sibling_contents = [
+      """
+      defmodule My.Admin do
+        use Ecto.Schema
+
+        embedded_schema do
+          field(:name, :string)
+        end
+      end
+      """,
+      """
+      defmodule My.Member do
+        use Ecto.Schema
+
+        schema "members" do
+          field(:name, :string)
+        end
+      end
+      """
+    ]
+
+    """
+    defmodule My.User do
+      use Ecto.Schema
+
+      schema "users" do
+        field(:name, :string)
+      end
+    end
+    """
+    |> SourceFile.parse("lib/my/user.ex")
+    |> EctoSchemaDirectories.ensure_all_siblings_are_schema(sibling_contents, [])
+    |> assert_issues([])
+  end
+
   defp assert_issues(issues, expected) do
     assert_lists_equal(issues, expected, fn issue, expected ->
       assert_structs_equal(issue, expected, [:category, :check, :filename, :line_no, :message])


### PR DESCRIPTION
# Description

The `Nicene.EctoSchemaDirectories` prevents regular modules to be in the same folder with Ecto Schema module. 

However, this rules prevented Ecto Embed schemas to be in the same folder, this PR addresses it to make sure Ecto Embed schema are considered schemas by the linter